### PR TITLE
Generate db typedefs in precommit hook

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   "**/*.[tj]s?(x)": ["eslint --fix --max-warnings=0", "prettier --check"],
+  "migrations/*.[tj]s": ["npm run generate:db-types"],
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,8 @@
 module.exports = {
   "**/*.[tj]s?(x)": ["eslint --fix --max-warnings=0", "prettier --check"],
-  "migrations/*.[tj]s": ["npm run generate:db-types"],
+  "migrations/*.[tj]s": [
+    "npm run start:migrate",
+    "npm run generate:db-types",
+    "git add app/db.d.ts",
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Jobs bot
+# Mod bot
+
+This code powers the Euno bot on Discord.
 
 Initial setup
 
@@ -22,8 +24,9 @@ Deployed with:
 
 Details:
 
-migrations with `yarn migrate:latest`. latest installed version is tracked in 2 tables of the sqlite data. schema changes must be done cautiously, should have a set up/tear down function tested before merging.
+migrations with `npm run start:migrate`. latest installed version is tracked in 2 tables of the sqlite data. schema changes must be done cautiously, should have a set up/tear down function tested before merging. Start a new migration with `npx kysely migrate:make <name>`
 
-seed data is stored in seeds/
+Migrations are stored in `migrations/`
+Generated DB types are stored in `app/db.d.ts` and generated automatically in a precommit hook.
 
 auth system is simple delegated auth to discord. accounts are created if not found locally, no passwords or secondary confirmation atm

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -1,0 +1,29 @@
+import type { ColumnType } from "kysely";
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
+export interface Guilds {
+  id: string | null;
+  settings: string | null;
+}
+
+export interface Sessions {
+  data: string | null;
+  expires: string | null;
+  id: string | null;
+}
+
+export interface Users {
+  authProvider: Generated<string | null>;
+  email: string | null;
+  externalId: string;
+  id: string;
+}
+
+export interface DB {
+  guilds: Guilds;
+  sessions: Sessions;
+  users: Users;
+}

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,6 +1,6 @@
 import SQLite from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
-import type { DB } from "kysely-codegen";
+import type { DB } from "./db";
 import { databaseUrl } from "./helpers/env";
 
 export { SqliteError } from "better-sqlite3";

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev:remix": "cross-env NODE_ENV=development binode --require ./mocks -- @remix-run/dev:remix watch",
     "kysely:seed": "kysely seed:run",
     "generate:css": "tailwindcss -o ./app/styles/tailwind.css",
-    "generate:db-types": "kysely-codegen --log-level debug --dialect sqlite",
+    "generate:db-types": "kysely-codegen --log-level debug --dialect sqlite --out-file ./app/db.d.ts",
     "start:mocks": "binode --require ./mocks -- @remix-run/serve:remix-serve build",
     "test:e2e:dev": "start-server-and-test dev http://localhost:3000 \"cypress open\"",
     "test:e2e:run": "exit; echo 'these tests are disabled because theyre broken'; cross-env PORT=8811 start-server-and-test start:mocks http://localhost:8811 \"cypress run\"",


### PR DESCRIPTION
If anything in migrations/ changes, it will run the migration, generate the types, and include the new typedefs in the commit. This is maybe a bit heavyweight for a precommit hook, but since codegen relies on inspecting an actual sqlite instance, that makes it tricky to do in CI. I'm mildly concerned this will end up causing some issues, as we already have some quirkiness in precommit hooks, but for now it seems like the most immediately workable solution